### PR TITLE
Add no-std capability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@
 //! [rsdoc]: https://crates.io/crates/rsdoc
 //! [PlantUML]: https://plantuml.com/
 
+#![no_std]
+
 /// Include a mermaid diagram in the documentation.
 ///
 /// This macro is meant to be used as argument of the `#[doc]` attribute.


### PR DESCRIPTION
Opening this since we are using mermaid for a few no-std crates in our repo here https://github.com/paritytech/polkadot-sdk  
Now there is an issue if it does not have no-std: https://github.com/paritytech/polkadot-sdk/issues/2866  

AFAIK there is downside to support no-std builds.