### PR TITLE
Bump mermaid dependency to 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple-mermaid"
 description = "Simple Mermaid diagrams RustDoc integration"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://github.com/glueball/simple-mermaid"
 repository = "https://github.com/glueball/simple-mermaid"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ macro_rules! _mermaid_inner {
                     include_str!($file), "\n",
                 "</pre>",
                 "<script type=\"module\">",
-                    "import mermaid from \"https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs\";",
+                    "import mermaid from \"https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs\";",
                     "var doc_theme = localStorage.getItem(\"rustdoc-theme\");",
                     "if (doc_theme === \"dark\" || doc_theme === \"ayu\") mermaid.initialize({theme: \"dark\"});",
                 "</script>")


### PR DESCRIPTION
Bump mermaid import to @11.

Bump version to 0.2.0 since going from mermaid@10 to mermaid@11 can be a breaking change.